### PR TITLE
Prepare Feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+
+# 1.2 (2017-09-25)
+
+- Adding the ability to `prepare()` a `UIImpactGenerator`.
+
+# 1.1 (2017-09-08)
+
+- Added the ability to specify which level of `UIImpactFeedbackStyle` you want.
+
+Supporting:
+- `.light`
+- `.medium`
+- `.heavy`
+
+# 1.0 (2016-12-08)
+
+- Initial release.

--- a/Example/FeedbackEffect/ViewController.swift
+++ b/Example/FeedbackEffect/ViewController.swift
@@ -16,9 +16,13 @@ class ViewController: UIViewController {
         // Uses the haptic feedback built into iOS along with an
         // alert sound to make a user feel they've finished a unit of work.
 
-        let selectionFeedback = HapticFeedback.notification(.success)
+        let notificationFeedback = HapticFeedback.notification(.success)
+
+        // We can optionally prepare the generator that relates to the feedback we're trying to activate.
+        notificationFeedback.prepare()
+
         let soundUrl = Bundle.main.url(forResource: "Success", withExtension: "m4a")
-        FeedbackEffect.play(sound: soundUrl, feedback: selectionFeedback)
+        FeedbackEffect.play(sound: soundUrl, feedback: notificationFeedback)
     }
     
     @IBAction func urlAndVibration(_ sender: Any) {
@@ -35,9 +39,10 @@ class ViewController: UIViewController {
         // Uses the haptic feedback built into iOS along with the tap sound
         // to make a user feel like they're really tapping a button.
 
-        let notificationFeedback = HapticFeedback.selection
+        let selectionFeedback = HapticFeedback.selection
+        selectionFeedback.prepare()
         let tapSound = SoundEffect.tap
-        FeedbackEffect.play(sound: tapSound, feedback: notificationFeedback)
+        FeedbackEffect.play(sound: tapSound, feedback: selectionFeedback)
     }
     
     @IBAction func toneAndVibration(_ sender: Any) {

--- a/FeedbackEffect.podspec
+++ b/FeedbackEffect.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'FeedbackEffect'
-  spec.version      = '1.1'
+  spec.version      = '1.2'
   spec.license      = { :type => 'MIT', :file => 'LICENSE' }
   spec.homepage     = 'https://github.com/mergesort/FeedbackEffect'
   spec.authors      =  { 'Joe Fabisevich' => 'github@fabisevi.ch' }

--- a/FeedbackEffect.podspec
+++ b/FeedbackEffect.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'FeedbackEffect'
-  spec.version      = '1.0'
+  spec.version      = '1.1'
   spec.license      = { :type => 'MIT', :file => 'LICENSE' }
   spec.homepage     = 'https://github.com/mergesort/FeedbackEffect'
   spec.authors      =  { 'Joe Fabisevich' => 'github@fabisevi.ch' }

--- a/Source/FeedbackEffect.swift
+++ b/Source/FeedbackEffect.swift
@@ -22,12 +22,30 @@ public protocol HapticEmitting {
 /// - notification: Used for calling `UINotificationFeedbackGenerator().notificationOccurred(notificationType)`.
 public enum HapticFeedback: HapticEmitting {
 
+    private static let impactGenerator = UIImpactFeedbackGenerator()
+    private static let selectionGenerator = UISelectionFeedbackGenerator()
+    private static let notificationGenerator = UINotificationFeedbackGenerator()
+
     case impact(UIImpactFeedbackStyle)
     case selection
     case notification(UINotificationFeedbackType)
 }
 
 extension HapticFeedback {
+
+    public func prepare() {
+        switch self {
+
+        case .impact:
+            HapticFeedback.impactGenerator.prepare()
+
+        case .selection:
+            HapticFeedback.selectionGenerator.prepare()
+
+        case .notification:
+            HapticFeedback.notificationGenerator.prepare()
+        }
+    }
 
     public func generateFeedback() {
         switch self {


### PR DESCRIPTION
You can now prime a `HapticFeedback`'s backing generator by calling `.prepare()` on it to match [Apple's preferred approach](https://developer.apple.com/documentation/uikit/uifeedbackgenerator).